### PR TITLE
フロントエンド向けのDockerfileを作成

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ all:
 	docker compose up --build 
 .PHONY: backend
 backend:
-	docker compose up --build backend
+	docker compose up --build backend volume-owner

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:16.17-bullseye as deps
+WORKDIR /app
+COPY package.json .yarnrc.yml yarn.lock /app/
+COPY .yarn/releases/ /app/.yarn/releases
+
+RUN yarn install --immutable
+
+FROM node:16.17-bullseye as builder
+WORKDIR /app
+COPY --from=deps /app/node_modules /app/node_modules
+COPY . /app
+
+RUN yarn build
+
+FROM gcr.io/distroless/nodejs:16 AS runner
+ENV NODE_ENV production
+ENV NEXT_TELEMETRY_DISABLED 1
+
+# COPY --from=builder --chown=nonroot:nonroot /app/public ./public
+
+COPY --from=builder --chown=nonroot:nonroot /app/.next/standalone ./
+COPY --from=builder --chown=nonroot:nonroot /app/.next/static ./.next/static
+
+EXPOSE 3000
+
+ENV PORT 3000
+
+CMD ["server.js"]

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  output: 'standalone',
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,5 +23,10 @@ services:
       - type: volume
         source: dbData
         target: /app
+  client:
+    build:
+      context: client
+    ports:
+      - "3000:3000"
 volumes:
   dbData:


### PR DESCRIPTION
ルートディレクトリで`make`を叩くと`localhost:3000`で本番環境向けにビルドしたサイトが、`localhost:8080`でgRPCサーバが立ち上がるようになっています。
